### PR TITLE
C1.0.2: Empty Application Commands

### DIFF
--- a/discord-bot/src/empty-commands.js
+++ b/discord-bot/src/empty-commands.js
@@ -1,0 +1,29 @@
+const { REST, Routes } = require('discord.js');
+const dotenv = require('dotenv');
+dotenv.config();
+
+/**
+ * Set the commands array to empty
+ */
+const commands = [];
+
+// Construct and prepare an instance of the REST module
+const rest = new REST().setToken(process.env.token);
+
+// Empty commands
+(async () => {
+    try {
+        console.log(`Started refreshing ${commands.length} application (/) commands.`);
+
+        // The put method is used to fully refresh all the commands in the guild with the empty set
+        const data = await rest.put(
+            Routes.applicationGuildCommands(process.env.clientID, process.env.guildID), 
+            { body: commands },
+        );
+        console.log(`Successfully emptied application (/) commands`)
+    }
+    catch(error) {
+        console.error(`[ERR]: ${error}`);
+    }
+
+})();


### PR DESCRIPTION
## Added empty-commands.js

A reiteration of the pre-existing `deploy-commands.js` file in the project. It empties the application command list instead of populating it with all defined commands inside of the `commands/utility` sub-directory. 

This feature was added specifically because I have two different bot applications using the same exact code base, and it was getting annoying seeing the slash command menu being so full. 